### PR TITLE
feat: drag-n-drop

### DIFF
--- a/configs/quickshell/pill/GlyphIcon.qml
+++ b/configs/quickshell/pill/GlyphIcon.qml
@@ -83,7 +83,12 @@ Item {
         "clock": { d: "M12 3a9 9 0 1 0 0 18a9 9 0 1 0 0-18z M12 7v5l3.5 2", fill: false },
         "cursor": { d: "M5 3l6 16 2-6 6-2L5 3z", fill: false },
         "video": { d: "M3 7.5a1.5 1.5 0 0 1 1.5-1.5h9A1.5 1.5 0 0 1 15 7.5v9A1.5 1.5 0 0 1 13.5 18h-9A1.5 1.5 0 0 1 3 16.5z M15 10l6-3v10l-6-3z", fill: false },
-        "record": { d: "M12 4a8 8 0 1 0 0 16a8 8 0 1 0 0-16z", fill: true }
+        "record": { d: "M12 4a8 8 0 1 0 0 16a8 8 0 1 0 0-16z", fill: true },
+        "phone": { d: "M6 2h12a2 2 0 0 1 2 2v16a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2z M12 18h.01", fill: false },
+        "folder": { d: "M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z", fill: false },
+        "file": { d: "M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z M13 2v7h7", fill: false },
+        "trash": { d: "M3 6h18 M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6 M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2 M10 11v6 M14 11v6", fill: false },
+        "airdrop": { d: "M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6z M8 12a4 4 0 0 1 8 0 M5 12a7 7 0 0 1 14 0 M2 12a10 10 0 0 1 20 0", fill: false }
     })
 
     readonly property var g: glyphs[name] !== undefined ? glyphs[name] : ({ d: "", fill: false })

--- a/configs/quickshell/pill/Pill.qml
+++ b/configs/quickshell/pill/Pill.qml
@@ -1,9 +1,12 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import QtQuick.Controls as Controls
 import QtQuick.Effects
 import QtQuick.Shapes
 import Quickshell
+import Quickshell.Io
+import Quickshell.Widgets
 import Quickshell.Services.Mpris
 import Quickshell.Networking
 import "Singletons"
@@ -52,6 +55,7 @@ Item {
     readonly property bool idlelockOpen: surface === "idlelock"
     readonly property bool animationOpen: surface === "animation"
     readonly property bool fontpickerOpen: surface === "fontpicker"
+    readonly property bool sharingOpen: surface === "sharing"
     readonly property bool settingsLike: settingsOpen || appearanceOpen || updatesOpen
     readonly property bool hasMedia: Mpris.players.values.length > 0
 
@@ -117,6 +121,10 @@ Item {
     readonly property real idlelockW: 392 * s
     readonly property real animationW: 392 * s
     readonly property real fontpickerW: 360 * s
+    readonly property real sharingW: 360 * s
+    readonly property real sharingH: (sharingSurface ? sharingSurface.implicitHeight : 0) + 26 * s
+    readonly property real dragOverW: 240 * s
+    readonly property real dragOverH: 58 * s
     readonly property real toastW: 342 * s
     readonly property real quickChooseW: 344 * s
     readonly property real quickChooseH: 76 * s
@@ -155,15 +163,25 @@ Item {
         look:       { size: () => Qt.size(lookW, look.implicitHeight + 29 * s), ame: look },
         idlelock:   { size: () => Qt.size(idlelockW, idlelock.implicitHeight + 29 * s), ame: idlelock },
         animation:  { size: () => Qt.size(animationW, animation.implicitHeight + 29 * s), ame: animation },
-        fontpicker: { size: () => Qt.size(fontpickerW, fontpicker.implicitHeight + 29 * s), ame: fontpicker }
+        fontpicker: { size: () => Qt.size(fontpickerW, fontpicker.implicitHeight + 29 * s), ame: fontpicker },
+        sharing:    { size: () => Qt.size(sharingW, sharingH), ame: sharingSurface }
     })
 
+    property bool dragActive: false
+    property string dragName: ""
+    property string dragPath: ""
+    property bool dragIsDir: false
+    property bool dragIsImage: false
+    property bool dragIsVideo: false
+    property bool dragIsMusic: false
+
     readonly property string mode: surfaceOpen && surfaces[surface] !== undefined ? surface
+        : (dragActive ? "dragOver"
         : (quickChoosing ? "quickChoose"
         : (quickCounting ? "quickCount"
         : (osdActive && !held ? "osd"
         : (toastActive && !held ? "toast"
-        : (expanded ? "hover" : "rest")))))
+        : (expanded ? "hover" : "rest"))))))
 
     signal requestSurface(string name)
     signal requestClose()
@@ -428,7 +446,8 @@ Item {
         toast: () => Qt.size(toastW, toastLoader.item ? toastLoader.item.implicitHeight + 24 * s : restH),
         hover: () => Qt.size(hoverW, hoverH),
         quickChoose: () => Qt.size(quickChooseW, quickChooseH),
-        quickCount:  () => Qt.size(quickCountW, quickCountH)
+        quickCount:  () => Qt.size(quickCountW, quickCountH),
+        dragOver:    () => Qt.size(dragOverW, dragOverH)
     })
 
     readonly property size targetSize: {
@@ -549,7 +568,8 @@ Item {
         anchors.fill: parent
         radius: pill.morphRadius
         border.width: 1
-        border.color: Theme.border
+        border.color: pill.mode === "dragOver" ? Theme.vermLit : Theme.border
+        Behavior on border.color { ColorAnimation { duration: Motion.fast } }
         gradient: Gradient {
             GradientStop { position: 0.0; color: Qt.alpha(Theme.cardTop, Flags.pillOpacity) }
             GradientStop { position: 1.0; color: Qt.alpha(Theme.cardBot, Flags.pillOpacity) }
@@ -685,7 +705,7 @@ Item {
     Item {
         id: rest
         anchors.fill: parent
-        opacity: (pill.expanded || pill.mode === "toast" || pill.mode === "osd" || pill.mode === "quickChoose" || pill.mode === "quickCount") ? 0 : Math.pow(pill.morphCloseness, 1.5)
+        opacity: (pill.expanded || pill.mode === "toast" || pill.mode === "osd" || pill.mode === "quickChoose" || pill.mode === "quickCount" || pill.mode === "dragOver") ? 0 : Math.pow(pill.morphCloseness, 1.5)
         visible: opacity > 0.01
         Behavior on opacity { NumberAnimation { duration: pill.mode === "rest" ? Motion.fast : 260 } }
 
@@ -797,6 +817,7 @@ Item {
                     }
                     Text {
                         anchors.horizontalCenter: parent.horizontalCenter
+                        visible: !pill.dragActive
                         text: clock.date
                         color: Theme.dim
                         font.family: Theme.font
@@ -1386,6 +1407,19 @@ Item {
         onRequestSurface: (name) => pill.requestSurface(name)
     }
 
+    SharingStore {
+        id: imageStore
+    }
+
+    SharingSurface {
+        id: sharingSurface
+        s: pill.s
+        open: pill.sharingOpen
+        store: imageStore
+        morphCloseness: pill.morphCloseness
+        onRequestClose: pill.requestClose()
+    }
+
     Osd {
         id: osd
         anchors.fill: parent
@@ -1653,6 +1687,150 @@ Item {
             anchors.fill: parent
             cursorShape: Qt.PointingHandCursor
             onClicked: ScreenRec.cancel()
+        }
+    }
+
+    Process {
+        id: checkDirProc
+        property string checkPath: ""
+        command: ["test", "-d", checkPath]
+        onExited: (exitCode) => {
+            pill.dragIsDir = (exitCode === 0);
+            if (pill.dragIsDir) {
+                pill.dragIsImage = false;
+                pill.dragIsVideo = false;
+                pill.dragIsMusic = false;
+            }
+        }
+    }
+
+    DropArea {
+        id: dropArea
+        anchors.fill: parent
+        keys: ["text/uri-list"]
+        enabled: !pill.surfaceOpen || pill.sharingOpen
+
+        onEntered: (drag) => {
+            drag.acceptProposedAction();
+            pill.dragActive = true;
+
+            if (drag.urls.length > 0) {
+                var urlStr = drag.urls[0].toString();
+                var path = decodeURIComponent(urlStr.indexOf("file://") === 0 ? urlStr.substring(7) : urlStr);
+                pill.dragPath = path;
+                pill.dragName = path.substring(path.lastIndexOf("/") + 1);
+                
+                var ext = path.split('.').pop().toLowerCase();
+                pill.dragIsImage = (ext === "png" || ext === "jpg" || ext === "jpeg" || ext === "webp" || ext === "gif" || ext === "svg");
+                pill.dragIsVideo = (ext === "mp4" || ext === "mkv" || ext === "webm" || ext === "avi" || ext === "mov" || ext === "flv" || ext === "wmv");
+                pill.dragIsMusic = (ext === "mp3" || ext === "wav" || ext === "ogg" || ext === "flac" || ext === "m4a" || ext === "aac" || ext === "opus" || ext === "wma");
+                pill.dragIsDir = false;
+                
+                checkDirProc.checkPath = path;
+                checkDirProc.running = true;
+            }
+        }
+        onPositionChanged: (drag) => {
+            drag.acceptProposedAction();
+        }
+        onExited: {
+            pill.dragActive = false;
+            pill.dragPath = "";
+            pill.dragName = "";
+            pill.dragIsImage = false;
+            pill.dragIsVideo = false;
+            pill.dragIsMusic = false;
+            pill.dragIsDir = false;
+            if (pill.sharingOpen) {
+                pill.requestClose();
+            }
+        }
+        onDropped: (drop) => {
+            drop.acceptProposedAction();
+            pill.dragActive = false;
+            pill.dragPath = "";
+            pill.dragName = "";
+            pill.dragIsImage = false;
+            pill.dragIsVideo = false;
+            pill.dragIsMusic = false;
+            pill.dragIsDir = false;
+            if (imageStore) {
+                imageStore.addFiles(drop.urls);
+            }
+            pill.requestSurface("sharing");
+        }
+    }
+
+    Item {
+        id: dragOverView
+        anchors.fill: parent
+        enabled: pill.mode === "dragOver"
+        opacity: pill.mode === "dragOver" ? Math.pow(pill.morphCloseness, 1.3) : 0
+        visible: opacity > 0.01
+        Behavior on opacity {
+            NumberAnimation { duration: Motion.standard; easing.type: Motion.easeStandard }
+        }
+
+        Item {
+            id: leftContent
+            anchors.left: parent.left
+            anchors.right: parent.right
+            height: parent.height
+
+            Row {
+                anchors.centerIn: parent
+                spacing: 8 * pill.s
+                width: Math.min(parent.width - 16 * pill.s, implicitWidth)
+
+                Item {
+                    id: previewContainer
+                    width: 32 * pill.s
+                    height: 32 * pill.s
+                    anchors.verticalCenter: parent.verticalCenter
+
+                    ClippingRectangle {
+                        anchors.fill: parent
+                        radius: 4 * pill.s
+                        color: Theme.tileBg
+                        visible: pill.dragIsImage
+
+                        Image {
+                            anchors.fill: parent
+                            source: pill.dragIsImage ? "file://" + pill.dragPath : ""
+                            fillMode: Image.PreserveAspectCrop
+                            asynchronous: true
+                            smooth: true
+                        }
+                    }
+
+                    GlyphIcon {
+                        anchors.centerIn: parent
+                        width: 20 * pill.s
+                        height: 20 * pill.s
+                        name: {
+                            if (pill.dragIsDir) return "folder";
+                            if (pill.dragIsVideo) return "video";
+                            if (pill.dragIsMusic) return "music";
+                            return "file";
+                        }
+                        color: Theme.iconDim
+                        stroke: 1.6
+                        visible: !pill.dragIsImage
+                    }
+                }
+
+                Text {
+                    id: dragText
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: Math.min(implicitWidth, leftContent.width - previewContainer.width - 24 * pill.s)
+                    text: pill.dragName
+                    color: Theme.cream
+                    font.family: Theme.font
+                    font.pixelSize: 11 * pill.s
+                    font.weight: Font.DemiBold
+                    elide: Text.ElideMiddle
+                }
+            }
         }
     }
 

--- a/configs/quickshell/pill/SharingStore.qml
+++ b/configs/quickshell/pill/SharingStore.qml
@@ -1,0 +1,102 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+Item {
+    id: imageStore
+
+    readonly property string cacheDir: (Quickshell.env("XDG_CACHE_HOME") || (Quickshell.env("HOME") + "/.cache")) + "/ricelin/dragdrop"
+
+    property var entries: []
+    property bool copying: false
+
+    function addFiles(urls) {
+        if (copying) return;
+
+        var validPaths = [];
+        for (var i = 0; i < urls.length; i++) {
+            var urlStr = urls[i].toString();
+            var path = decodeURIComponent(urlStr.indexOf("file://") === 0 ? urlStr.substring(7) : urlStr);
+            if (path.length > 0) {
+                validPaths.push(path);
+            }
+        }
+
+        if (validPaths.length === 0) return;
+
+        copying = true;
+        copyProc.command = ["sh", "-c", 'dest="$1"; shift; mkdir -p "$dest" && cp -r "$@" "$dest"', "_", cacheDir].concat(validPaths);
+        copyProc.running = true;
+    }
+
+    function clear() {
+        clearProc.running = true;
+    }
+
+    function refresh() {
+        listProc.running = true;
+    }
+
+    function deleteFile(path) {
+        deleteSingleProc.command = ["rm", "-rf", path];
+        deleteSingleProc.running = true;
+    }
+
+    property Process copyProc: Process {
+        onExited: (exitCode) => {
+            imageStore.copying = false;
+            if (exitCode === 0) {
+                imageStore.refresh();
+            }
+        }
+    }
+
+    property Process listProc: Process {
+        command: ["sh", "-c", "find \"$1\" -mindepth 1 -maxdepth 1 -printf '%y:%p\\n' 2>/dev/null", "_", imageStore.cacheDir]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                var lines = this.text.split("\n");
+                var out = [];
+                for (var i = 0; i < lines.length; i++) {
+                    var line = lines[i].trim();
+                    if (line.length === 0) continue;
+                    var colonIndex = line.indexOf(":");
+                    if (colonIndex === -1) continue;
+                    var typeChar = line.substring(0, colonIndex);
+                    var path = line.substring(colonIndex + 1);
+                    var name = path.substring(path.lastIndexOf("/") + 1);
+                    var isDir = typeChar === "d";
+                    var ext = path.split('.').pop().toLowerCase();
+                    var isImage = !isDir && (ext === "png" || ext === "jpg" || ext === "jpeg" || ext === "webp" || ext === "gif" || ext === "svg");
+                    var isVideo = !isDir && (ext === "mp4" || ext === "mkv" || ext === "webm" || ext === "avi" || ext === "mov" || ext === "flv" || ext === "wmv");
+                    var isMusic = !isDir && (ext === "mp3" || ext === "wav" || ext === "ogg" || ext === "flac" || ext === "m4a" || ext === "aac" || ext === "opus" || ext === "wma");
+                    out.push({
+                        path: path,
+                        name: name,
+                        url: "file://" + path,
+                        isDir: isDir,
+                        isImage: isImage,
+                        isVideo: isVideo,
+                        isMusic: isMusic
+                    });
+                }
+                imageStore.entries = out;
+            }
+        }
+    }
+
+    property Process clearProc: Process {
+        command: ["sh", "-c", "rm -rf \"$1\"/*", "_", imageStore.cacheDir]
+        onExited: {
+            imageStore.refresh();
+        }
+    }
+
+    property Process deleteSingleProc: Process {
+        onExited: {
+            imageStore.refresh();
+        }
+    }
+
+    Component.onCompleted: refresh()
+}

--- a/configs/quickshell/pill/SharingSurface.qml
+++ b/configs/quickshell/pill/SharingSurface.qml
@@ -1,0 +1,341 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls as Controls
+import QtQuick.Effects
+import QtQuick.Shapes
+import Quickshell
+import Quickshell.Io
+import Quickshell.Widgets
+import "Singletons"
+
+PillSurface {
+    id: sharingSurface
+
+    mTop: 13
+    mLeft: 12
+    mRight: 12
+    mBottom: 13
+
+    property var store
+    property bool draggingOut: false
+    property string currentTab: "all"
+    readonly property var filteredEntries: {
+        if (!store) return [];
+        var list = store.entries;
+        if (currentTab === "files") {
+            return list.filter(function(e) { return !e.isDir; });
+        } else if (currentTab === "folders") {
+            return list.filter(function(e) { return e.isDir; });
+        }
+        return list;
+    }
+
+    enabled: open || draggingOut
+    visible: open || draggingOut
+
+    implicitHeight: mainCol.implicitHeight
+    clip: true
+
+    HoverHandler {
+        onHoveredChanged: {
+            if (!hovered && sharingSurface.open) {
+                sharingSurface.requestClose();
+            }
+        }
+    }
+
+    Column {
+        id: mainCol
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        spacing: 10 * sharingSurface.s
+
+        Item {
+            width: parent.width
+            height: 28 * sharingSurface.s
+
+            Row {
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: 10 * sharingSurface.s
+
+                Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    visible: Flags.showGlyphs
+                    text: "繋"
+                    color: Theme.cream
+                    font.family: Theme.fontJp
+                    font.weight: Font.Medium
+                    font.pixelSize: 16 * sharingSurface.s
+                }
+
+                SettingsSeg {
+                    s: sharingSurface.s
+                    anchors.verticalCenter: parent.verticalCenter
+                    options: [
+                        { label: "ALL", value: "all" },
+                        { label: "FILES", value: "files" },
+                        { label: "FOLDERS", value: "folders" }
+                    ]
+                    value: sharingSurface.currentTab
+                    onPicked: (val) => { sharingSurface.currentTab = val; }
+                }
+            }
+            Item {
+                id: clearBtn
+                anchors.right: parent.right
+                anchors.rightMargin: 12 * sharingSurface.s
+                anchors.verticalCenter: parent.verticalCenter
+                width: clearRow.implicitWidth
+                height: clearRow.implicitHeight
+                visible: sharingSurface.store && sharingSurface.store.entries.length > 0
+
+                Row {
+                    id: clearRow
+                    spacing: 4 * sharingSurface.s
+                    anchors.fill: parent
+
+                    GlyphIcon {
+                        width: 12 * sharingSurface.s
+                        height: 12 * sharingSurface.s
+                        name: "trash"
+                        color: trashArea.containsMouse ? Theme.cream : Theme.iconDim
+                        stroke: 1.6
+                    }
+
+                    Text {
+                        text: "CLEAR"
+                        color: trashArea.containsMouse ? Theme.cream : Theme.iconDim
+                        font.family: Theme.font
+                        font.pixelSize: 8.5 * sharingSurface.s
+                        font.weight: Font.DemiBold
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+                }
+
+                MouseArea {
+                    id: trashArea
+                    anchors.fill: parent
+                    anchors.margins: -4 * sharingSurface.s
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        if (sharingSurface.store) {
+                            sharingSurface.store.clear();
+                        }
+                    }
+                }
+            }
+
+            GlyphIcon {
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                name: "close"
+                color: closeArea.containsMouse ? Theme.cream : Theme.iconDim
+                stroke: 1.8
+
+                MouseArea {
+                    id: closeArea
+                    anchors.fill: parent
+                    anchors.margins: -6 * sharingSurface.s
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: sharingSurface.requestClose()
+                }
+            }
+        }
+
+        Rectangle {
+            width: parent.width
+            height: 1
+            color: Theme.hair
+        }
+
+        Controls.ScrollView {
+            id: scrollView
+            width: parent.width
+            height: Math.min(flowLayout.implicitHeight, 220 * sharingSurface.s)
+            clip: true
+            Controls.ScrollBar.vertical.policy: Controls.ScrollBar.AlwaysOff
+            Controls.ScrollBar.horizontal.policy: Controls.ScrollBar.AlwaysOff
+
+            Flow {
+                id: flowLayout
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: {
+                    var count = sharingSurface.filteredEntries.length;
+                    var cols = Math.min(count, 3);
+                    return cols > 0 ? (cols * 106 + (cols - 1) * 8) * sharingSurface.s : 0;
+                }
+                spacing: 8 * sharingSurface.s
+                visible: sharingSurface.store && sharingSurface.filteredEntries.length > 0
+
+                Repeater {
+                    model: sharingSurface.filteredEntries
+
+                    delegate: Item {
+                        id: delegateItem
+                        required property var modelData
+                        width: 106 * sharingSurface.s
+                        height: 66 * sharingSurface.s
+
+                        property bool dragActive: false
+                        Drag.active: dragActive
+                        Drag.dragType: Drag.Automatic
+                        Drag.supportedActions: Qt.CopyAction
+                        Drag.mimeData: {
+                            "text/uri-list": delegateItem.modelData ? [Qt.url(delegateItem.modelData.url)] : []
+                        }
+                        Drag.onDragFinished: {
+                            delegateItem.dragActive = false;
+                            sharingSurface.draggingOut = false;
+                            sharingSurface.requestClose();
+                        }
+
+                        readonly property real hold: trashHeat.hold
+                        readonly property bool committing: trashHeat.hold >= trashHeat.tapThreshold
+                        readonly property real commitProgress: Math.max(0, (trashHeat.hold - trashHeat.tapThreshold) / (1 - trashHeat.tapThreshold))
+
+                        ClippingRectangle {
+                            anchors.fill: parent
+                            radius: 10 * sharingSurface.s
+                            color: Theme.tileBg
+
+                            Image {
+                                anchors.fill: parent
+                                visible: !!(delegateItem.modelData && delegateItem.modelData.isImage)
+                                source: (delegateItem.modelData && delegateItem.modelData.isImage) ? delegateItem.modelData.url : ""
+                                fillMode: Image.PreserveAspectCrop
+                                asynchronous: true
+                                smooth: true
+                            }
+
+                            Column {
+                                anchors.centerIn: parent
+                                width: parent.width - 8 * sharingSurface.s
+                                spacing: 4 * sharingSurface.s
+                                visible: !delegateItem.modelData || !delegateItem.modelData.isImage
+
+                                GlyphIcon {
+                                    anchors.horizontalCenter: parent.horizontalCenter
+                                    width: 20 * sharingSurface.s
+                                    height: 20 * sharingSurface.s
+                                    name: {
+                                        if (!delegateItem.modelData) return "file";
+                                        if (delegateItem.modelData.isDir) return "folder";
+                                        if (delegateItem.modelData.isVideo) return "video";
+                                        if (delegateItem.modelData.isMusic) return "music";
+                                        return "file";
+                                    }
+                                    color: Theme.iconDim
+                                    stroke: 1.6
+                                }
+
+                                Text {
+                                    anchors.horizontalCenter: parent.horizontalCenter
+                                    width: parent.width
+                                    text: delegateItem.modelData ? delegateItem.modelData.name : ""
+                                    color: Theme.cream
+                                    font.family: Theme.font
+                                    font.pixelSize: 8.5 * sharingSurface.s
+                                    elide: Text.ElideMiddle
+                                    horizontalAlignment: Text.AlignHCenter
+                                }
+                            }
+
+                            Rectangle {
+                                id: consume
+                                anchors.left: parent.left
+                                anchors.right: parent.right
+                                anchors.bottom: parent.bottom
+                                height: parent.height * delegateItem.commitProgress
+                                visible: delegateItem.committing
+                                gradient: Gradient {
+                                    GradientStop { position: 0.0; color: Qt.alpha(Theme.vermBurn, 0.66) }
+                                    GradientStop { position: 0.74; color: Qt.alpha(Theme.vermLit, 0.30) }
+                                    GradientStop { position: 1.0; color: Qt.alpha(Theme.flameGlow, 0.0) }
+                                }
+
+                                Rectangle {
+                                    anchors.left: parent.left
+                                    anchors.right: parent.right
+                                    anchors.top: parent.top
+                                    height: 2 * sharingSurface.s
+                                    opacity: Math.min(1, delegateItem.commitProgress * 3)
+                                    gradient: Gradient {
+                                        orientation: Gradient.Horizontal
+                                        GradientStop { position: 0.0; color: Qt.alpha(Theme.flameGlow, 0.0) }
+                                        GradientStop { position: 0.5; color: Theme.flameGlow }
+                                        GradientStop { position: 1.0; color: Qt.alpha(Theme.flameGlow, 0.0) }
+                                    }
+                                }
+                            }
+                        }
+
+                        Rectangle {
+                            anchors.fill: parent
+                            radius: 10 * sharingSurface.s
+                            color: "transparent"
+                            border.width: 1
+                            border.color: delegateItem.committing ? Theme.vermLit : (hoverArea.containsMouse ? Theme.vermLit : Theme.border)
+                            Behavior on border.color { ColorAnimation { duration: Motion.fast } }
+                            scale: hoverArea.containsMouse ? 1.03 : 1.0
+                            Behavior on scale { NumberAnimation { duration: Motion.fast; easing.type: Easing.OutQuad } }
+                        }
+
+                        HeatHold {
+                            id: trashHeat
+                            tapThreshold: 0.25
+
+                            onConfirmed: {
+                                if (sharingSurface.store && delegateItem.modelData) {
+                                    sharingSurface.store.deleteFile(delegateItem.modelData.path);
+                                }
+                            }
+                        }
+
+                        MouseArea {
+                            id: hoverArea
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+
+                            property point pressPos
+
+                            onPressed: (mouse) => {
+                                pressPos = Qt.point(mouse.x, mouse.y);
+                                trashHeat.press();
+                            }
+                            onPositionChanged: (mouse) => {
+                                if (pressed) {
+                                    var threshold = 10 * sharingSurface.s;
+                                    if (Math.abs(mouse.x - pressPos.x) > threshold || Math.abs(mouse.y - pressPos.y) > threshold) {
+                                        if (!delegateItem.dragActive) {
+                                            trashHeat.cancel();
+                                            sharingSurface.draggingOut = true;
+                                            delegateItem.dragActive = true;
+                                            delegateItem.Drag.startDrag();
+                                        }
+                                    }
+                                }
+                            }
+                            onReleased: trashHeat.release()
+                            onExited: trashHeat.cancel()
+                        }
+                    }
+                }
+            }
+        }
+
+        Text {
+            anchors.horizontalCenter: parent.horizontalCenter
+            visible: !sharingSurface.store || sharingSurface.filteredEntries.length === 0
+            text: "No files"
+            color: Theme.faint
+            font.family: Theme.font
+            font.pixelSize: 11 * sharingSurface.s
+        }
+    }
+}

--- a/configs/quickshell/pill/shell.qml
+++ b/configs/quickshell/pill/shell.qml
@@ -146,6 +146,7 @@ ShellRoot {
         function system(mon: string): void { root.toggleSurface(mon, "sysmon"); }
         function clipboard(mon: string): void { root.toggleSurface(mon, "clipboard"); }
         function wallpaper(mon: string): void { root.toggleSurface(mon, "wallpaper"); }
+        function sharing(mon: string): void { root.toggleSurface(mon, "sharing"); }
         function media(mon: string): void {
             if (Mpris.players.values.length > 0)
                 root.toggleSurface(mon, "media");
@@ -219,7 +220,9 @@ ShellRoot {
             color: "transparent"
             exclusionMode: ExclusionMode.Ignore
             WlrLayershell.layer: WlrLayer.Overlay
-            WlrLayershell.keyboardFocus: (surfaceOpen || pill.quickChoosing) ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.OnDemand
+            WlrLayershell.keyboardFocus: (surfaceOpen || pill.quickChoosing)
+                ? (surface === "sharing" ? WlrKeyboardFocus.None : WlrKeyboardFocus.Exclusive)
+                : WlrKeyboardFocus.OnDemand
             WlrLayershell.namespace: "pill"
 
             anchors { top: true; left: true; right: true; bottom: true }


### PR DESCRIPTION
Introduce SharingStore to manage caching and operations (add, list, delete, clear) on dragged files.

- Add SharingSurface with tabs for filtering (All, Files, Folders) and hold-to-delete interaction.
- Integrate DropArea into Pill to toggle a visual drag-over preview overlay.


https://github.com/user-attachments/assets/4f155b11-5b16-4b99-8060-76faaf3031cf

